### PR TITLE
fix(tiled): prevent panic when loading a .TSX file with custom properties

### DIFF
--- a/src/tiled/resources.rs
+++ b/src/tiled/resources.rs
@@ -332,22 +332,25 @@ impl TiledAssets {
                         },
                     };
 
-                    // Animated tiles
                     tileset_xml
                         .special_tiles
                         .iter()
                         .map(|tile| (tile.id, tile.clone()))
                         .for_each(|(atlas_index, tile)| {
-                            let frames = tile.animation.unwrap().frames;
-                            let anim = animations.register(RawTileAnimation {
-                                // TODO maybe support?
-                                fps: (1000. / frames[0].duration as f32) as u32,
-                                sequence: frames
-                                    .into_iter()
-                                    .map(|frame| (texture_index as u32, frame.tile_id))
-                                    .collect(),
-                            });
-                            animated_tiles.insert(atlas_index, anim);
+                            // Animated tiles
+                            if let Some(tiled_animation) = tile.animation {
+                                let frames = tiled_animation.frames;
+                                let anim = animations.register(RawTileAnimation {
+                                    // TODO maybe support?
+                                    fps: (1000. / frames[0].duration as f32) as u32,
+                                    sequence: frames
+                                        .into_iter()
+                                        .map(|frame| (texture_index as u32, frame.tile_id))
+                                        .collect(),
+                                });
+                                animated_tiles.insert(atlas_index, anim);
+                            }
+                            // TODO: handle tiles with custom properties ?
                         });
 
                     tilesets_records.insert(tileset_xml.name.clone(), self.tilesets.len());


### PR DESCRIPTION
Code was expecting "special tiles" to define the "animation" field which is not the case for tiles with only custom properties defined directly in the tileset and no animation.

Extract of .TSX file that reproduce the issue:
```
# no problem with this one: 'animation' is defined
<tile id="400" type="Global">
  <properties>
   <property name="Collision" type="bool" value="true"/>
  </properties>
  <animation>
   <frame tileid="291" duration="100"/>
   <frame tileid="324" duration="100"/>
  </animation>
</tile>

# this one causes a panic because no 'animation' is defined
<tile id="401" type="Global">
  <properties>
   <property name="Collision" type="bool" value="true"/>
  </properties>
</tile>
```
