### PR TITLE
fix(serializing): fix compilation with 'serializing' feature when 'algorithm' is not used

### DIFF
--- a/src/serializing/map/load.rs
+++ b/src/serializing/map/load.rs
@@ -6,7 +6,7 @@ use bevy::{
         bundle::Bundle,
         component::Component,
         entity::Entity,
-        system::{Commands, Query, Res},
+        system::{Commands, Query, Res, ResMut},
     },
     hierarchy::DespawnRecursiveExt,
 };
@@ -30,8 +30,6 @@ use crate::{
     serializing::map::PATH_TILES,
     tilemap::{algorithm::path::PathTilemap, chunking::storage::PathTileChunkedStorage},
 };
-#[cfg(feature = "algorithm")]
-use bevy::ecs::system::ResMut;
 
 #[cfg(feature = "physics")]
 use crate::{

--- a/src/serializing/map/save.rs
+++ b/src/serializing/map/save.rs
@@ -5,7 +5,7 @@ use bevy::{
     ecs::{
         component::Component,
         entity::Entity,
-        system::{Commands, Query},
+        system::{Commands, Query, Res},
     },
     reflect::Reflect,
 };
@@ -29,8 +29,6 @@ use super::{SerializedTilemap, TilemapLayer, TILEMAP_META, TILES};
 
 #[cfg(feature = "algorithm")]
 use crate::{algorithm::pathfinding::PathTilemaps, serializing::map::PATH_TILES};
-#[cfg(feature = "algorithm")]
-use bevy::ecs::system::Res;
 
 #[cfg(feature = "physics")]
 use crate::{


### PR DESCRIPTION
If you select the 'serializing' feature without the 'algorithm' feature, the crate does not compile.