### PR TITLE
feat(tiled): add a more explicit error message when trying to use primitive properties

### DIFF
--- a/src/tiled/xml/property.rs
+++ b/src/tiled/xml/property.rs
@@ -65,6 +65,9 @@ impl<'de> Deserialize<'de> for ClassInstance {
                                     .collect(),
                             );
                         }
+                        "@value" => {
+                            panic!("Primitive properties are not allowed in ClassInstance (name={})", name.unwrap_or("UNK".to_owned()));
+                        }
                         _ => panic!("Unknown key for ClassInstance: {}", key),
                     }
                 }


### PR DESCRIPTION
Minor update again :)

Display a more meaningfull message to the user if he tries to use a primitive property directly in the TiledObject