### PR TITLE
feat(tiled): when a class or a class property is expected but not found, use its default value

### DIFF
--- a/assets/tiled/Tilemap.tiled-project
+++ b/assets/tiled/Tilemap.tiled-project
@@ -59,6 +59,80 @@
         {
             "color": "#ffa0a0a4",
             "drawFill": true,
+            "id": 12,
+            "members": [
+                {
+                    "name": "Block",
+                    "propertyType": "Block",
+                    "type": "class",
+                    "value": {
+                    }
+                }
+            ],
+            "name": "BlockBundle",
+            "type": "class",
+            "useAs": [
+                "property",
+                "map",
+                "layer",
+                "object",
+                "tile",
+                "tileset",
+                "wangcolor",
+                "wangset",
+                "project"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 9,
+            "members": [
+            ],
+            "name": "DetectArea",
+            "type": "class",
+            "useAs": [
+                "property",
+                "map",
+                "layer",
+                "object",
+                "tile",
+                "tileset",
+                "wangcolor",
+                "wangset",
+                "project"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 11,
+            "members": [
+                {
+                    "name": "DetectArea",
+                    "propertyType": "DetectArea",
+                    "type": "class",
+                    "value": {
+                    }
+                }
+            ],
+            "name": "DetectAreaBundle",
+            "type": "class",
+            "useAs": [
+                "property",
+                "map",
+                "layer",
+                "object",
+                "tile",
+                "tileset",
+                "wangcolor",
+                "wangset",
+                "project"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
             "id": 8,
             "members": [
                 {
@@ -128,10 +202,44 @@
         {
             "color": "#ffa0a0a4",
             "drawFill": true,
-            "id": 9,
+            "id": 10,
+            "members": [
+                {
+                    "name": "Moveable",
+                    "propertyType": "MoveableObject",
+                    "type": "class",
+                    "value": {
+                    }
+                },
+                {
+                    "name": "Player",
+                    "propertyType": "Player",
+                    "type": "class",
+                    "value": {
+                    }
+                }
+            ],
+            "name": "PlayerBundle",
+            "type": "class",
+            "useAs": [
+                "property",
+                "map",
+                "layer",
+                "object",
+                "tile",
+                "tileset",
+                "wangcolor",
+                "wangset",
+                "project"
+            ]
+        },
+        {
+            "color": "#ffa0a0a4",
+            "drawFill": true,
+            "id": 13,
             "members": [
             ],
-            "name": "DetectArea",
+            "name": "PlainBlockBundle",
             "type": "class",
             "useAs": [
                 "property",

--- a/assets/tiled/Tilemap.tiled-session
+++ b/assets/tiled/Tilemap.tiled-session
@@ -3,12 +3,12 @@
         "height": 4300,
         "width": 2
     },
-    "activeFile": "tilemaps/isometricCube.tmx",
+    "activeFile": "",
     "expandedProjectPaths": [
         "tilesets",
-        "tilemaps",
+        "world_test",
         ".",
-        "world_test"
+        "tilemaps"
     ],
     "fileStates": {
         "D:/Program Files/Tiled/examples/desert.tmx": {
@@ -138,10 +138,10 @@
                 2
             ],
             "scale": 2,
-            "selectedLayer": 0,
+            "selectedLayer": 2,
             "viewCenter": {
-                "x": 146.75,
-                "y": 123.5
+                "x": 74.25,
+                "y": 71
             }
         },
         "tilemaps/hexgonal.tmx": {
@@ -156,7 +156,7 @@
             "scale": 3,
             "selectedLayer": 0,
             "viewCenter": {
-                "x": 99.16666666666666,
+                "x": 99.16666666666669,
                 "y": 14.666666666666657
             }
         },
@@ -164,19 +164,19 @@
             "expandedObjectLayers": [
                 2
             ],
-            "scale": 3,
-            "selectedLayer": 0,
+            "scale": 4,
+            "selectedLayer": 2,
             "viewCenter": {
-                "x": 135.83333333333331,
-                "y": 138.33333333333331
+                "x": 93.875,
+                "y": 38.25
             }
         },
         "tilemaps/isometricCube.tmx": {
             "scale": 5.5,
             "selectedLayer": 0,
             "viewCenter": {
-                "x": 100.81818181818181,
-                "y": 3.4545454545454533
+                "x": 111.72727272727273,
+                "y": 127.63636363636364
             }
         },
         "tilemaps/orthogonal.tmj": {
@@ -192,15 +192,16 @@
                 3
             ],
             "expandedObjectLayers": [
+                7,
+                3,
                 4,
-                5,
-                3
+                5
             ],
-            "scale": 11,
-            "selectedLayer": 5,
+            "scale": 5.5,
+            "selectedLayer": 3,
             "viewCenter": {
-                "x": 105.86363636363637,
-                "y": 61.45454545454545
+                "x": 111.54545454545455,
+                "y": 54.36363636363636
             }
         },
         "tilemaps/tilesets/Hexagonal.tsx": {
@@ -278,23 +279,21 @@
     "map.tileWidth": 32,
     "map.width": 10,
     "openFiles": [
-        "tilemaps/isometricCube.tmx"
     ],
     "project": "Tilemap.tiled-project",
-    "property.type": "object",
+    "property.type": "Block",
     "recentFiles": [
-        "tilemaps/isometricCube.tmx",
-        "tilemaps/infinite.tmx",
-        "tilemaps/hexagonal.tmx",
-        "tilemaps/isometric.tmx",
-        "tilesets/IsometricCube.tsx",
-        "tilesets/IsomtricCubic.tsx",
         "tilemaps/orthogonal.tmx",
-        "tilesets/8pxSquare.tsx",
-        "tilemaps/Caves.tmx",
+        "tilemaps/hexagonal.tmx",
+        "tilesets/IsometricCube.tsx",
         "tilesets/Isometric.tsx",
         "tilesets/Hexagonal.tsx",
-        "tilesets/Squares.tsx"
+        "tilesets/8pxSquare.tsx",
+        "tilesets/Tileset2.tsx",
+        "tilesets/Tileset1.tsx",
+        "tilesets/Squares.tsx",
+        "tilemaps/isometric.tmx",
+        "tilemaps/infinite.tmx"
     ],
     "tileset.lastUsedFormat": "tsx",
     "tileset.tileSize": {

--- a/assets/tiled/tilemaps/orthogonal.tmx
+++ b/assets/tiled/tilemaps/orthogonal.tmx
@@ -33,45 +33,34 @@
  </layer>
  <group id="3" name="Objects">
   <objectgroup id="4" name="Region">
-   <object id="1" name="Bridge" type="DetectArea" x="82.8295" y="58.8352" width="47.1875" height="20.875">
-    <properties>
-     <property name="Area" type="class" propertytype="DetectArea"/>
-    </properties>
-   </object>
-   <object id="3" name="Torch" type="DetectArea" x="27.0625" y="48" width="32.875" height="25">
-    <properties>
-     <property name="Area" type="class" propertytype="DetectArea"/>
-    </properties>
+   <object id="1" name="Bridge" type="DetectAreaBundle" x="82.8295" y="58.8352" width="47.1875" height="20.875"/>
+   <object id="3" name="Torch" type="DetectAreaBundle" x="27.0625" y="48" width="32.875" height="25">
     <ellipse/>
    </object>
-   <object id="4" name="WaterFall" type="DetectArea" x="136" y="88">
-    <properties>
-     <property name="Area" type="class" propertytype="DetectArea"/>
-    </properties>
+   <object id="4" name="WaterFall" type="DetectAreaBundle" x="136" y="88">
     <polygon points="0,0 0,32 -8,32 -8,48 16,48 16,32 8,32 8,0"/>
    </object>
   </objectgroup>
   <objectgroup id="5" name="Tiles" opacity="0.66" tintcolor="#aaaaff">
-   <object id="7" name="StackingA" type="PlainBlock" gid="389" x="59.6825" y="44.3392" width="32" height="16" rotation="73.12"/>
-   <object id="5" name="BlockTest" type="PlainBlock" gid="2147484033" x="64" y="80" width="16" height="16"/>
-   <object id="6" name="BlockProps" type="Block" gid="386" x="136" y="72" width="16" height="16">
+   <object id="7" name="StackingA" type="PlainBlockBundle" gid="389" x="59.6825" y="44.3392" width="32" height="16" rotation="73.12"/>
+   <object id="5" name="BlockTest" type="PlainBlockBundle" gid="2147484033" x="64" y="80" width="16" height="16"/>
+   <object id="6" name="BlockProps" type="BlockBundle" gid="386" x="136" y="72" width="16" height="16">
     <properties>
      <property name="Block" type="class" propertytype="Block">
       <properties>
        <property name="Collision" type="bool" value="true"/>
        <property name="Hardness" type="float" value="20"/>
        <property name="Name" value="Box"/>
-       <property name="Shape" propertytype="ShapeType" value="Square"/>
        <property name="Tint" type="color" value="#ff443eb9"/>
       </properties>
      </property>
     </properties>
    </object>
-   <object id="8" name="StackingB" type="PlainBlock" gid="390" x="69.125" y="85.5" width="32" height="16"/>
+   <object id="8" name="StackingB" type="PlainBlockBundle" gid="390" x="69.125" y="85.5" width="32" height="16"/>
   </objectgroup>
  </group>
  <objectgroup id="7" name="Player">
-  <object id="10" name="Player" type="Player" gid="55" x="108" y="50.5455" width="8" height="8">
+  <object id="10" name="Player" type="PlayerBundle" gid="55" x="108" y="50.5455" width="8" height="8">
    <properties>
     <property name="Moveable" type="class" propertytype="MoveableObject">
      <properties>

--- a/examples/tiled.rs
+++ b/examples/tiled.rs
@@ -47,11 +47,12 @@ fn main() {
             ignore_unregisterd_objects: true,
             z_index: 0.,
         })
-        .register_tiled_object::<BlockBundle>("Block")
-        .register_tiled_object::<PlainBlockBundle>("PlainBlock")
-        .register_tiled_object::<PlayerBundle>("Player")
-        .register_tiled_object::<DetectAreaBundle>("DetectArea")
+        .register_tiled_object::<BlockBundle>("BlockBundle")
+        .register_tiled_object::<PlainBlockBundle>("PlainBlockBundle")
+        .register_tiled_object::<PlayerBundle>("PlayerBundle")
+        .register_tiled_object::<DetectAreaBundle>("DetectAreaBundle")
         .register_type::<Block>()
+        .register_type::<Player>()
         .insert_resource(RenderChunkSort::XAndY)
         .run();
 }
@@ -85,7 +86,7 @@ fn switching(
  * So if you want to know what they do, you can go to examples/ldtk.rs.
  */
 
-#[derive(TiledObject, Bundle)]
+#[derive(TiledObject, Bundle, Default)]
 #[spawn_sprite]
 pub struct PlainBlockBundle {
     // You have to use `TiledClass`es for objects.
@@ -93,16 +94,16 @@ pub struct PlainBlockBundle {
     pub block: PlainBlock,
 }
 
-#[derive(TiledClass, Component)]
+#[derive(TiledClass, Component, Default)]
 pub struct PlainBlock;
 
-#[derive(TiledObject, Bundle)]
+#[derive(TiledObject, Bundle, Default)]
 #[spawn_sprite]
 pub struct BlockBundle {
     pub block: Block,
 }
 
-#[derive(TiledClass, Component, Reflect)]
+#[derive(TiledClass, Component, Reflect, Default)]
 pub struct Block {
     #[tiled_name = "Collision"]
     pub collision: bool,
@@ -116,8 +117,9 @@ pub struct Block {
     pub shape: ShapeType,
 }
 
-#[derive(TiledEnum, Reflect)]
+#[derive(TiledEnum, Reflect, Default)]
 pub enum ShapeType {
+    #[default]
     Square,
     Isometry,
     Hexagon,
@@ -125,7 +127,7 @@ pub enum ShapeType {
     Eclipse,
 }
 
-#[derive(TiledObject, Bundle)]
+#[derive(TiledObject, Bundle, Default)]
 #[spawn_sprite]
 #[global_object]
 // Generate the collider according to the shape.
@@ -136,25 +138,32 @@ pub struct PlayerBundle {
     pub moveable: MoveableObject,
 }
 
-#[derive(TiledClass, Component, Default)]
+#[derive(TiledClass, Component, Reflect, Default)]
 pub struct Player {
     #[tiled_name = "Hp"]
     pub hp: f32,
-    #[tiled_default]
+    // This property is not assigned an explicit value in Tiled:
+    // it does not even appear in the .tmx file,
+    // it will be initialized with a default value
+    #[tiled_name = "Level"]
     pub level: i32,
+    // This property does not exist at all in Tiled:
+    // it does not even appear in the .tmx file,
+    // it will be initialized with a default value
+    pub mp: i32,
 }
 
-#[derive(TiledClass, Component)]
+#[derive(TiledClass, Component, Default)]
 pub struct MoveableObject {
     #[tiled_name = "Speed"]
     pub speed: f32,
 }
 
-#[derive(TiledObject, Bundle)]
+#[derive(TiledObject, Bundle, Default)]
 #[shape_as_collider]
 pub struct DetectAreaBundle {
     pub detect_area: DetectArea,
 }
 
-#[derive(TiledClass, Component)]
+#[derive(TiledClass, Component, Default)]
 pub struct DetectArea;

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -37,7 +37,7 @@ pub fn derive_tiled_objects(input: proc_macro::TokenStream) -> proc_macro::Token
     tiled_object::expand_tiled_objects_derive(syn::parse(input).unwrap())
 }
 
-#[proc_macro_derive(TiledClass, attributes(tiled_default, tiled_name))]
+#[proc_macro_derive(TiledClass, attributes(tiled_name))]
 pub fn derive_tiled_classes(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     tiled_class::expand_tiled_class_derive(syn::parse(input).unwrap())
 }


### PR DESCRIPTION
Several things in this PR, mostly to handle Tiled SW corner cases and try to streamline imports from Tiled.

1/ In Tiled SW, if we declare that an object is of a given class but do not manually assign any value to the class properties, properties / TiledClass'es won't even appear in the .tmx file :

```
# There should be a 'TriggerArea' ClassInstance
<objectgroup id="2" name="Object Layer">
  <object id="15" type="BlockBundle" x="48.7402" y="82.6464" width="72.3534" height="29.6679"/>
</objectgroup>
```
Instead of panic'ing, if I don't find the TiledClass in .tmx I just initialize the object with its default() method (macros/src/tiled_class.rs:34)

2/ In Tiled SW, if we declare that an object is of a given class but only manually assign some of the class properties, properties / TiledClass'es that were not set won't even appear in the .tmx file :

```
# The 'TriggerArea' ClassInstance should also have a 'y' property
<objectgroup id="2" name="Object Layer">
  <object id="15" type="BlockBundle" x="48.7402" y="82.6464" width="72.3534" height="29.6679">
   <properties>
    <property name="trigger" type="class" propertytype="TriggerArea">
     <properties>
      <property name="x" type="int" value="24"/>
     </properties>
    </property>
   </properties>
  </object>
</objectgroup>
```

Instead of panic'ing, if I don't find the field in .tmx, I retrieve its default value from TiledClass default() method (macros/src/tiled_class.rs:56/78)

3/ Direct consequence of 1/ and 2/ is that we don't need the 'tiled_default' anymore for TiledClass since we now always do it.

4/ Finally, I updated tiled example files to reflect this change and uniformize things a bit. Global idea is to always define a "*Bundle" class for object (our TiledObject's) that will contains the actual data, stored in sub-objects (TiledClass'es). Before, the object was of a given class bu also included a property with this class (and only the later one was used). Even if it increases a bit the number of custom types / classes used in Tiled SW, I believe it improves readability / understanding of the crate. I'll try to do some documentation around the Tiled feature in a next PR.

Let me know if you have any question / any remark. I'm pretty new to Rust / Bevy and opensource in general but eager to contribute ! ;)