### PR TITLE
fix(tiled): fix objects auto-mapping when using 'tiled_name' (broken by #30)

### DIFF
--- a/macros/src/tiled_class.rs
+++ b/macros/src/tiled_class.rs
@@ -75,9 +75,9 @@ fn expand_class_fields_rename(
     };
 
     quote::quote!(
-        #field_name: if data.properties.contains_key(stringify!(#name)) {
+        #field_name: if data.properties.contains_key(#name) {
             data.properties
-                .get(stringify!(#name))
+                .get(#name)
                 .unwrap()
                 .clone()
                 .into()


### PR DESCRIPTION
Mistake from my previous change: we were always using the default value, stringify was adding quotes around the name.

I did not update the RELEASE_NOTE.md since it's a fix of a non-released feature: let me know if you still want me to do it