### PR TITLE
fix(tiled): fix Tiled enum parsing, only worked with 'ShapeType'

### DIFF
--- a/RELEASE_NOTE.md
+++ b/RELEASE_NOTE.md
@@ -11,3 +11,4 @@
 - Wrong stacking order for tiles that are rendered larger than the slot. #26
 - Ldtk sprite flip is incorrect #25
 - fix compilation with 'serializing' feature when 'algorithm' is not used #28
+- Fix Tiled enum parsing, only worked with 'ShapeType' #33

--- a/macros/src/tiled_enum.rs
+++ b/macros/src/tiled_enum.rs
@@ -23,7 +23,7 @@ pub fn expand_tiled_enum_derive(input: syn::DeriveInput) -> proc_macro::TokenStr
     }
 
     quote::quote!(
-        impl bevy_entitiles::tiled::traits::TiledEnum for ShapeType {
+        impl bevy_entitiles::tiled::traits::TiledEnum for #ty {
             fn get_identifier(ident: &str) -> Self {
                 match ident {
                     #(#variants_cton)*


### PR DESCRIPTION
Seems like a typo, it broke usage of enums not named 'ShapeType'